### PR TITLE
Added support for IP Check

### DIFF
--- a/src/main/kotlin/com/blitzoffline/giveall/GiveAll.kt
+++ b/src/main/kotlin/com/blitzoffline/giveall/GiveAll.kt
@@ -46,7 +46,7 @@ class GiveAll : JavaPlugin() {
         }
 
         val vaultHook = settingsManager.settings.hooks["vault"]
-        if (vaultHook != null && vaultHook == true) {
+        if (vaultHook != null && vaultHook) {
             val vault = Bukkit.getPluginManager().getPlugin("Vault")
 
             if (vault == null) {

--- a/src/main/kotlin/com/blitzoffline/giveall/settings/holder/IpMode.kt
+++ b/src/main/kotlin/com/blitzoffline/giveall/settings/holder/IpMode.kt
@@ -1,0 +1,9 @@
+package com.blitzoffline.giveall.settings.holder
+
+enum class IpMode {
+    ALL,
+    RANDOM,
+    FIRST,
+    LAST,
+    NONE
+}

--- a/src/main/kotlin/com/blitzoffline/giveall/settings/holder/SettingsHolder.kt
+++ b/src/main/kotlin/com/blitzoffline/giveall/settings/holder/SettingsHolder.kt
@@ -6,5 +6,6 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable
 data class SettingsHolder(
     val giveRewardsToSender: Boolean = false,
     val requirePermission: Boolean = false,
-    val hooks: Map<String, Boolean> = mapOf("vault" to true)
+    val hooks: Map<String, Boolean> = mapOf("vault" to true),
+    val ipMode: IpMode = IpMode.ALL
 )

--- a/src/main/kotlin/com/blitzoffline/giveall/util/VersionHelper.kt
+++ b/src/main/kotlin/com/blitzoffline/giveall/util/VersionHelper.kt
@@ -18,7 +18,7 @@ object VersionHelper {
         return try {
             Class.forName("com.destroystokyo.paper.PaperConfig")
             true
-        } catch (ignored: ClassNotFoundException) {
+        } catch (_: ClassNotFoundException) {
             false
         }
     }

--- a/src/main/resources/settings.conf
+++ b/src/main/resources/settings.conf
@@ -14,3 +14,10 @@ hooks {
 }
 # If you enable this, only players with the permission 'giveall.receive' will be able to get the rewards.
 require-permission=false
+# Select what happens when there are multiple players logged in with the same IP address.
+# ALL - gives rewards to all players even if they share an IP address.
+# RANDOM - gives rewards to one random player from the players sharing an IP address.
+# FIRST - gives rewards to one player from the players sharing an IP address. The player is chosen based on alphabetical order.
+# LAST - gives rewards to one player from the players sharing an IP address. The player is chosen based on reversed alphabetical order.
+# NONE - do not give rewards at all to players that share an IP address.
+ip-mode=ALL


### PR DESCRIPTION
Added a new setting: `ip-mode`. This new option allows giving rewards to all, none or 1 of the players that share an IP address.


```yml
# Select what happens when there are multiple players logged in with the same IP address.
# ALL - gives rewards to all players even if they share an IP address.
# RANDOM - gives rewards to one random player from the players sharing an IP address.
# FIRST - gives rewards to one player from the players sharing an IP address. The player is chosen based on alphabetical order.
# LAST - gives rewards to one player from the players sharing an IP address. The player is chosen based on reversed alphabetical order.
# NONE - do not give rewards at all to players that share an IP address.
ip-mode=ALL
```